### PR TITLE
init.pp should ensure that /etc/dd-agent is a directory, not just ensure present

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -362,7 +362,7 @@ class datadog_agent(
   }
 
   file { '/etc/dd-agent':
-    ensure  => present,
+    ensure  => directory,
     owner   => $dd_user,
     group   => $dd_group,
     mode    => '0755',


### PR DESCRIPTION
If you set the package version to be absent, the /etc/dd-agent directory doesn't get created when the package resource runs. This causes the file resource in init.pp to create it, but since it's just set to present instead of a directory, dependent resources bomb out because they can't get created - like the conf.d directory.